### PR TITLE
docs: streamline test script and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.0
+- Consolidated `npm test` script for linting and type-checking
+- Version aligned with card's 0.8.0 release
+
 ## 0.8.0-dev.12
 - Stable UI editor for common options (entities, weather, focus window, height).
 - Robust native weather in headers (HA strategies + aggregation for hourly).

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -11,8 +11,7 @@
 
 ```bash
 npm ci
-npm run lint       # ESLint (no warnings allowed)
-npm run check      # tsc --noEmit
+npm test           # run lint + type-check
 npm run build      # bundle for HA
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multi-calendar-grid-card",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Home Assistant Lovelace card: Multi-Calendar Grid Card (Lit + TypeScript)",
   "private": true,
   "type": "module",
@@ -20,6 +20,7 @@
     "build": "esbuild ./src/multi-calendar-grid-card.ts --bundle --minify --sourcemap --outfile=./dist/multi-calendar-grid-card.js",
     "check": "tsc --noEmit",
     "lint": "eslint \"src/**/*.{ts,js}\" --max-warnings=0",
+    "test": "npm run check && npm run lint",
     "format": "prettier --write ."
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- bump package version to 0.8.0 for upcoming release
- add combined `npm test` script and update development guide
- document 0.8.0 release in changelog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1fede5630832db8685e7abc3aa85a