### PR TITLE
fix: align time scale with calendar grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.8.0-dev.13
+- Fix misalignment between time scale and calendar grid.
+
 ## 0.8.0-dev.12
 - Stable UI editor for common options (entities, weather, focus window, height).
 - Robust native weather in headers (HA strategies + aggregation for hourly).

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,6 +1,6 @@
 # Troubleshooting
 
-> Baseline: **v0.8.0-dev.12**
+> Baseline: **v0.8.0-dev.13**
 
 ## “Unknown card type encountered ‘multi-calendar-grid-card’”
 The resource isn’t loaded. Add the module under **Settings → Dashboards → Resources**, or fix the URL.
@@ -24,5 +24,5 @@ If you previously hid a calendar in this card, its state is persisted in `localS
 HA tried to use the editor before it was defined. Ensure the editor bundle is included in the same built file (or lazy‑loaded) and that you hard‑reload the editor after updating.
 
 ## Slight misalignment of left time scale vs grid
-Known in dev.12 for some themes. A later patch measures the header height and inserts a mirrored spacer in the time column.
+Fixed in dev.13. The time column now mirrors the header height with a sticky spacer.
 

--- a/src/multi-calendar-grid-card.ts
+++ b/src/multi-calendar-grid-card.ts
@@ -396,6 +396,8 @@ export class MultiCalendarGridCard extends LitElement {
     .allday{padding:6px 8px; display:flex; flex-wrap:wrap; gap:6px 6px; border-bottom:1px solid var(--divider-color,#e0e0e0)}
     .pill{background: var(--secondary-background-color, rgba(0,0,0,.08)); color: var(--primary-text-color,#111); border-radius:10px; padding:2px 8px; font-size:12px; max-width:100%; white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
     .timecol{background:var(--card-background-color,#fff); position:relative}
+    .timecol .spacer{position:sticky; top:0; background:var(--card-background-color,#fff); z-index:5; border-bottom:1px solid var(--divider-color,#e0e0e0)}
+    .timecol .ticks{position:relative}
     .tick{position:absolute; left:0; right:0; border-top:1px solid rgba(0,0,0,.22); z-index:1}
     .tick.minor{border-top:1px dashed rgba(0,0,0,.14)}
     .hour-label{position:absolute; top:-8px; left:6px; font-size:12px; color:var(--secondary-text-color); z-index:2; background: var(--card-background-color,#fff); padding:0 4px}
@@ -930,6 +932,7 @@ export class MultiCalendarGridCard extends LitElement {
     const ticks: unknown[] = [];
     const pxPerMin = this._pxPerMin();
     const step = Number(this._config.slot_minutes ?? DEFAULTS.slot_minutes);
+    const columnHeight = Math.round(1440 * pxPerMin);
     const use12 = this._config.time_format === "12";
     const lang = this._lang();
     const tf = new Intl.DateTimeFormat(lang, { hour: "numeric", minute: "2-digit", hour12: use12 });
@@ -942,7 +945,10 @@ export class MultiCalendarGridCard extends LitElement {
         ticks.push(html`<div class="hour-label" style=${`top:${top - 8}px`}>${label}</div>`);
       }
     }
-    return html`<div class="timecol" style=${`grid-column:1/2; grid-row:1/-1; position:relative; padding-top:${this._timeColPad}px`}>${ticks}</div>`;
+    return html`<div class="timecol" style="grid-column:1/2; grid-row:1/-1; position:relative;">
+      <div class="spacer" style=${`height:${this._timeColPad}px`}></div>
+      <div class="ticks" style=${`height:${columnHeight}px`}>${ticks}</div>
+    </div>`;
   }
 
   private _gridLinesDom(pxPerMin: number, stepMin: number) {


### PR DESCRIPTION
## Summary
- ensure time scale starts below calendar header
- document resolved time scale alignment issue

## Testing
- `npm test`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b227d0fabc832db2b8e8ae68ec7ffd