### PR TITLE
Overlay all-day events and fix duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.8.0-dev.14
+- Overlay all-day events on the grid and remove per-day spacer.
+- Fix all-day events incorrectly showing on the following day.
+
+## 0.8.0-dev.13
+- Fix misalignment between time scale and calendar grid.
+
 ## 0.8.0-dev.12
 - Stable UI editor for common options (entities, weather, focus window, height).
 - Robust native weather in headers (HA strategies + aggregation for hourly).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A compact, **7‑day** time‑grid view that overlays multiple Home Assistant ca
 
 - **Rolling 7‑day window** starting **today** by default (`start_today: true`).
 - **Overlay multiple calendars** with per‑calendar color + name.
-- **All‑day row** + timed events with smart overlap layout (lanes).
+- **All‑day events overlay** + timed events with smart overlap layout (lanes).
 - **Weather summary in each day header** (icon + low/high), using a robust multi‑strategy forecast fetch.
 - **Sticky day headers** (date + weather) while you scroll the time grid.
 - **“Now” indicator** line (optional).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,7 +13,7 @@
 1. **Rendering (LitElement)**
    - Header toolbar (legend and navigation)
    - Sticky day headers (date + weather)
-   - All‑day row
+   - All‑day events overlay
    - Time grid body (00:00–24:00); events positioned using minute offsets
 
 2. **Data fetchers**

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,6 +1,6 @@
 # Troubleshooting
 
-> Baseline: **v0.8.0-dev.12**
+> Baseline: **v0.8.0-dev.14**
 
 ## “Unknown card type encountered ‘multi-calendar-grid-card’”
 The resource isn’t loaded. Add the module under **Settings → Dashboards → Resources**, or fix the URL.
@@ -24,5 +24,5 @@ If you previously hid a calendar in this card, its state is persisted in `localS
 HA tried to use the editor before it was defined. Ensure the editor bundle is included in the same built file (or lazy‑loaded) and that you hard‑reload the editor after updating.
 
 ## Slight misalignment of left time scale vs grid
-Known in dev.12 for some themes. A later patch measures the header height and inserts a mirrored spacer in the time column.
+Fixed in dev.14. All-day events overlay the grid, and the time column automatically pads to match the header height.
 

--- a/src/multi-calendar-grid-card.ts
+++ b/src/multi-calendar-grid-card.ts
@@ -393,9 +393,10 @@ export class MultiCalendarGridCard extends LitElement {
     .grid{position:relative; display:grid; gap:1px; background:var(--divider-color,#e0e0e0)}
     .col{background:var(--card-background-color,#fff); position:relative}
     .dayhdr{position:sticky; top:0; background:var(--card-background-color,#fff); z-index:5; font-weight:800; padding:8px 10px; border-bottom:1px solid var(--divider-color,#e0e0e0); display:flex; align-items:center; justify-content:space-between; gap:8px}
-    .allday{padding:6px 8px; display:flex; flex-wrap:wrap; gap:6px 6px; border-bottom:1px solid var(--divider-color,#e0e0e0)}
+    .allday{position:absolute; top:0; left:0; right:0; padding:6px 8px; display:flex; flex-wrap:wrap; gap:6px 6px; background:var(--card-background-color,#fff); z-index:3}
     .pill{background: var(--secondary-background-color, rgba(0,0,0,.08)); color: var(--primary-text-color,#111); border-radius:10px; padding:2px 8px; font-size:12px; max-width:100%; white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
     .timecol{background:var(--card-background-color,#fff); position:relative}
+    .timecol .ticks{position:relative}
     .tick{position:absolute; left:0; right:0; border-top:1px solid rgba(0,0,0,.22); z-index:1}
     .tick.minor{border-top:1px dashed rgba(0,0,0,.14)}
     .hour-label{position:absolute; top:-8px; left:6px; font-size:12px; color:var(--secondary-text-color); z-index:2; background: var(--card-background-color,#fff); padding:0 4px}
@@ -805,8 +806,17 @@ export class MultiCalendarGridCard extends LitElement {
       (typeof s0 === "string" && s0.includes("T")) ||
       (typeof e0 === "string" && e0.includes("T"));
 
-    const s = new Date(s0);
-    const e = new Date(e0);
+    let s: Date;
+    let e: Date;
+    if (!hasTime) {
+      const [sy, sm = 1, sd = 1] = String(s0).split("-").map(Number);
+      const [ey, em = 1, ed = 1] = String(e0).split("-").map(Number);
+      s = new Date(sy, sm - 1, sd);
+      e = new Date(ey, em - 1, ed);
+    } else {
+      s = new Date(s0);
+      e = new Date(e0);
+    }
 
     return {
       s,
@@ -930,6 +940,7 @@ export class MultiCalendarGridCard extends LitElement {
     const ticks: unknown[] = [];
     const pxPerMin = this._pxPerMin();
     const step = Number(this._config.slot_minutes ?? DEFAULTS.slot_minutes);
+    const columnHeight = Math.round(1440 * pxPerMin);
     const use12 = this._config.time_format === "12";
     const lang = this._lang();
     const tf = new Intl.DateTimeFormat(lang, { hour: "numeric", minute: "2-digit", hour12: use12 });
@@ -942,7 +953,9 @@ export class MultiCalendarGridCard extends LitElement {
         ticks.push(html`<div class="hour-label" style=${`top:${top - 8}px`}>${label}</div>`);
       }
     }
-    return html`<div class="timecol" style=${`grid-column:1/2; grid-row:1/-1; position:relative; padding-top:${this._timeColPad}px`}>${ticks}</div>`;
+    return html`<div class="timecol" style="grid-column:1/2; grid-row:1/-1; position:relative;">
+      <div class="ticks" style=${`height:${columnHeight}px;margin-top:${this._timeColPad}px`}>${ticks}</div>
+    </div>`;
   }
 
   private _gridLinesDom(pxPerMin: number, stepMin: number) {
@@ -978,9 +991,9 @@ export class MultiCalendarGridCard extends LitElement {
       if (isToday && todayColor) { headerBg = todayColor; bodyBg = todayColor; }
       else if (isWknd && weekendColor) { headerBg = weekendColor; bodyBg = weekendColor; }
 
-      const allDay = this._config.show_all_day
+      const allDay = this._config.show_all_day && (day?.allDay?.length)
         ? html`<div class="allday">
-            ${(day?.allDay || []).map(
+            ${(day.allDay || []).map(
               (ev) => html`<div class="pill" @click=${() => this._open(ev)}>${ev.summary}
               ${ev.alsoColors && ev.alsoColors.length ? html`<span style="margin-left:6px; display:inline-flex; gap:3px; vertical-align:middle;">${ev.alsoColors.map(c => html`<span style="width:8px;height:8px;border-radius:2px;display:inline-block;box-shadow:0 0 0 1px rgba(0,0,0,.25) inset;background:${c}"></span>`)}</span>` : nothing}
             </div>`
@@ -1019,8 +1032,7 @@ export class MultiCalendarGridCard extends LitElement {
             <div>${label}</div>
             ${wx}
           </div>
-          ${allDay}
-          <div class="body" style=${`height:${columnHeight}px; position:relative; ${bodyBg ? `background-color:${bodyBg};` : ""}`}>${gridLines}${timed}${nowLine}</div>
+          <div class="body" style=${`height:${columnHeight}px; position:relative; ${bodyBg ? `background-color:${bodyBg};` : ""}`}>${allDay}${gridLines}${timed}${nowLine}</div>
         </div>
       `);
     }


### PR DESCRIPTION
## Summary
- Render all-day events over the grid and drop the per-day spacer
- Correct all-day event parsing so they don't spill into the next day
- Document new all-day overlay behaviour and troubleshooting info

## Testing
- `npm test`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b227d0fabc832db2b8e8ae68ec7ffd