### PR TITLE
feat: allow build name override for sourcemap

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -24,10 +24,16 @@ npm run build      # bundle for HA
 
 ## Local testing in HA
 
-1. Copy the build to `/config/www/dev/multi-calendar-grid-card-dev12.js`.
-2. Add a **Resource** pointing to `/local/dev/multi-calendar-grid-card-dev12.js` (type `module`).
-3. In a test view, add the card via YAML (see README examples).
-4. Shift+Reload the dashboard after each build (or clear cache).
+1. Build with a versioned name (the `.map` will match automatically):
+
+   ```bash
+   BUILD_NAME=multi-calendar-grid-card-dev12 npm run build
+   ```
+
+2. Copy `dist/multi-calendar-grid-card-dev12.js` to `/config/www/dev/`.
+3. Add a **Resource** pointing to `/local/dev/multi-calendar-grid-card-dev12.js` (type `module`).
+4. In a test view, add the card via YAML (see README examples).
+5. Shift+Reload the dashboard after each build (or clear cache).
 
 ## Release hygiene
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "build": "esbuild ./src/multi-calendar-grid-card.ts --bundle --minify --sourcemap --outfile=./dist/multi-calendar-grid-card.js",
+    "build": "node scripts/build.mjs",
     "check": "tsc --noEmit",
     "lint": "eslint \"src/**/*.{ts,js}\" --max-warnings=0",
     "format": "prettier --write .",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,0 +1,15 @@
+import { mkdir } from 'node:fs/promises';
+import { build } from 'esbuild';
+
+const outName = process.env.BUILD_NAME || 'multi-calendar-grid-card';
+const outfile = `./dist/${outName}.js`;
+
+await mkdir('./dist', { recursive: true });
+
+await build({
+  entryPoints: ['./src/multi-calendar-grid-card.ts'],
+  bundle: true,
+  minify: true,
+  sourcemap: true,
+  outfile,
+});


### PR DESCRIPTION
## Summary
- build bundle via `scripts/build.mjs` so `BUILD_NAME` decides the output filename
- ensure sourcemap and `sourceMappingURL` stay in sync for custom builds
- document dev workflow using `BUILD_NAME`

## Testing
- `npm run lint`
- `npm run check`
- `npm test`
- `BUILD_NAME=multi-calendar-grid-card-dev12 npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b2bba819a0832dbab4489ddee5508a