### PR TITLE
feat: add internationalization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ start_today: true          # NEW: start the 7-day view at “today”
 slot_min_time: '07:00:00'
 slot_max_time: '22:00:00'
 slot_minutes: 60
+locale: de               # optional language override
+time_format: 24          # optional time format (12 or 24)
 px_per_min: 0.8
 height_vh: 80
 header_compact: false
@@ -90,6 +92,8 @@ weather_compact: false     # false = show icon + hi/low; true = tighter
 | `slot_min_time`        | `HH:MM:SS`      | `07:00:00` | Earliest visible hour. |
 | `slot_max_time`        | `HH:MM:SS`      | `22:00:00` | Latest visible hour. |
 | `slot_minutes`         | number          | `30`    | Minor grid step in minutes (1–180). |
+| `locale`               | string          | HA      | Language override (defaults to Home Assistant). |
+| `time_format`          | `'12'`/`'24'`   | HA      | Hour format override. |
 | `px_per_min`           | number          | `1.6`   | Vertical scale: pixels per minute. |
 | `height_vh`            | number          | `80`    | Scroll area height in viewport units. |
 | `header_compact`       | boolean         | `false` | Smaller top header. |
@@ -137,6 +141,7 @@ The most useful docs live in the `/docs` directory:
 - **[Architecture](docs/ARCHITECTURE.md)** – How the card is structured and how data flows.
 - **[Development Guide](docs/DEVELOPMENT.md)** – Local dev, building, linting, and release process.
 - **[Troubleshooting](docs/TROUBLESHOOTING.md)** – Common issues and fixes.
+- **[Internationalization](docs/I18N.md)** – Add or update translations.
 
 ### Architecture Decision Records (ADRs)
 

--- a/docs/I18N.md
+++ b/docs/I18N.md
@@ -1,0 +1,16 @@
+# Internationalization
+
+The grid calendar card supports multiple languages and local date/time formats.
+Translations live in [`src/locales`](../src/locales).
+
+## Adding a new language
+1. Copy `src/locales/en.ts` to `src/locales/<lang>.ts`.
+2. Translate each string.
+3. Import your file in `src/i18n.ts` and add it to `STRINGS`.
+4. Submit a pull request.
+
+## Configuration options
+- `locale`: override the language for the card. Defaults to Home Assistant's setting.
+- `time_format`: set `'12'` or `'24'` to force a 12h or 24h clock. Defaults to Home Assistant.
+
+These settings are optional; when omitted the card follows Home Assistant's locale.

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,7 @@ export type MultiCalendarGridCardConfig = {
   slot_max_time?: string;
   slot_minutes?: number;
   locale?: string;
+  time_format?: "12" | "24";
   show_now_indicator?: boolean;
   show_all_day?: boolean;
 
@@ -40,7 +41,6 @@ export const DEFAULTS: Required<
     | "slot_min_time"
     | "slot_max_time"
     | "slot_minutes"
-    | "locale"
     | "show_now_indicator"
     | "show_all_day"
     | "height_vh"
@@ -55,7 +55,6 @@ export const DEFAULTS: Required<
   slot_min_time: "07:00:00",
   slot_max_time: "22:00:00",
   slot_minutes: 30,
-  locale: "en",
   show_now_indicator: true,
   show_all_day: true,
   height_vh: 80,

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,23 +1,14 @@
+import en from "./locales/en";
+import de from "./locales/de";
+
 export const STRINGS = {
-  en: {
-    prev: "Prev",
-    next: "Next",
-    today: "Today",
-    today_pill: "Today",
-    no_events: "No events in this range.",
-    event_details: "Event details",
-    close: "Close",
-    aria_prev_week: "Previous week",
-    aria_next_week: "Next week",
-    aria_today: "Go to current week",
-    failed_load_prefix: "Failed to load:",
-  },
+  en,
+  de,
 } as const;
 
-export function tr(
-  lang: string | undefined,
-  key: keyof typeof STRINGS["en"],
-): string {
+export type TranslationKey = keyof typeof en;
+
+export function tr(lang: string | undefined, key: TranslationKey): string {
   const base = (lang || "en").split("-")[0] as keyof typeof STRINGS;
   return STRINGS[base]?.[key] || STRINGS.en[key] || key;
 }

--- a/src/locale.ts
+++ b/src/locale.ts
@@ -1,0 +1,51 @@
+export type HourCycle = "h12" | "h23";
+
+export const detectLang = (hass: any, cfgLocale?: string): string =>
+  cfgLocale || hass?.locale?.language || "en";
+
+export const detectHourCycle = (
+  hass: any,
+  cfgTimeFormat?: string,
+): HourCycle => ((cfgTimeFormat || hass?.locale?.time_format) === "12" ? "h12" : "h23");
+
+export const shortDate = (d: Date, lang: string) =>
+  new Intl.DateTimeFormat(lang, { day: "2-digit", month: "short" }).format(d);
+
+export const weekdayDate = (d: Date, lang: string) =>
+  new Intl.DateTimeFormat(lang, {
+    weekday: "short",
+    day: "2-digit",
+    month: "short",
+  }).format(d);
+
+export const time = (d: Date, lang: string, cycle: HourCycle) =>
+  new Intl.DateTimeFormat(lang, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: cycle,
+  }).format(d);
+
+export const formatRange = (
+  s: Date,
+  e: Date,
+  allDay: boolean,
+  lang: string,
+  cycle: HourCycle,
+) => {
+  if (allDay) {
+    const same = s.toDateString() === e.toDateString();
+    const endAdj = new Date(e.getFullYear(), e.getMonth(), e.getDate());
+    endAdj.setMilliseconds(-1);
+    return same
+      ? weekdayDate(s, lang)
+      : `${weekdayDate(s, lang)} → ${weekdayDate(endAdj, lang)}`;
+  }
+  if (s.toDateString() === e.toDateString()) {
+    return `${weekdayDate(s, lang)} • ${time(s, lang, cycle)}–${time(e, lang, cycle)}`;
+  }
+  return `${weekdayDate(s, lang)} ${time(s, lang, cycle)} → ${weekdayDate(e, lang)} ${time(
+    e,
+    lang,
+    cycle,
+  )}`;
+};

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -1,0 +1,13 @@
+export default {
+  prev: "Zurück",
+  next: "Weiter",
+  today: "Heute",
+  today_pill: "Heute",
+  no_events: "Keine Ereignisse in diesem Zeitraum.",
+  event_details: "Termindetails",
+  close: "Schließen",
+  aria_prev_week: "Vorherige Woche",
+  aria_next_week: "Nächste Woche",
+  aria_today: "Zur aktuellen Woche",
+  failed_load_prefix: "Fehler beim Laden:",
+} as const;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1,0 +1,13 @@
+export default {
+  prev: "Prev",
+  next: "Next",
+  today: "Today",
+  today_pill: "Today",
+  no_events: "No events in this range.",
+  event_details: "Event details",
+  close: "Close",
+  aria_prev_week: "Previous week",
+  aria_next_week: "Next week",
+  aria_today: "Go to current week",
+  failed_load_prefix: "Failed to load:",
+} as const;


### PR DESCRIPTION
## Summary
- add localization helpers for language and time formatting
- refactor card to use translations with English and German locales
- document translation workflow and locale/time format config options

## Testing
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b382027798832d997e9b6fb89d1acb