### PR TITLE
ci: upload build artifact for HA testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,7 @@ jobs:
       - run: npm run lint
       - run: npm run check
       - run: npm run build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: multi-calendar-grid-card
+          path: dist/multi-calendar-grid-card.js


### PR DESCRIPTION
## Summary
- upload `multi-calendar-grid-card.js` as a build artifact

## Testing
- `npm ci`
- `npm run lint`
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b388aa999c832d99c0182ca774c752