### PR TITLE
refactor: streamline configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Removed
+- Legacy options `start_today`, `first_day`, `show_all_day`, `header_compact`, `weather_days`, `weather_compact`, and `storage_key`.
+- Renamed `slot_min_time`/`slot_max_time`/`slot_minutes` to `view_start_time`/`view_end_time`/`view_slot_minutes`.
+
 ## [0.8.1] - 2025-08-31
 ### Added
 - Internationalization support. ([#7](https://github.com/kenika/grid-calendar-card/pull/7), [#8](https://github.com/kenika/grid-calendar-card/pull/8))

--- a/README.md
+++ b/README.md
@@ -60,25 +60,19 @@ entities:
     color: '#03a9f4'
 
 # Time-grid & layout
-first_day: 1               # 0=Sun … 6=Sat (used if start_today: false)
-start_today: true          # NEW: start the 7-day view at “today”
-slot_min_time: '07:00:00'
-slot_max_time: '22:00:00'
-slot_minutes: 60
+view_start_time: '07:00:00'
+view_end_time: '22:00:00'
+view_slot_minutes: 60
 locale: de               # optional language override
 time_format: 24          # optional time format (12 or 24)
 px_per_min: 0.8
 height_vh: 80
-header_compact: false
 show_now_indicator: true
-show_all_day: true
 remember_offset: true
 data_refresh_minutes: 5
 
 # Weather in day headers (optional)
 weather_entity: weather.integra_langsbau_1_3
-weather_days: 7            # default 7
-weather_compact: false     # false = show icon + hi/low; true = tighter
 ```
 
 ---
@@ -88,23 +82,17 @@ weather_compact: false     # false = show icon + hi/low; true = tighter
 | Key                    | Type            | Default | Description |
 |------------------------|-----------------|---------|-------------|
 | `entities`             | list            | —       | Calendars to overlay. Each item: `{ entity, name?, color? }`. |
-| `first_day`            | number (0–6)    | `1`     | Week start (Mon=1). Used only when `start_today: false`. |
-| `start_today`          | boolean         | `true`  | **NEW**. When `true`, the 7-day view starts at today (rolling window). |
-| `slot_min_time`        | `HH:MM:SS`      | `07:00:00` | Earliest visible hour. |
-| `slot_max_time`        | `HH:MM:SS`      | `22:00:00` | Latest visible hour. |
-| `slot_minutes`         | number          | `30`    | Minor grid step in minutes (1–180). |
+| `view_start_time`      | `HH:MM:SS`      | `07:00:00` | Earliest visible hour. |
+| `view_end_time`        | `HH:MM:SS`      | `22:00:00` | Latest visible hour. |
+| `view_slot_minutes`    | number          | `30`    | Minor grid step in minutes (1–180). |
 | `locale`               | string          | HA      | Language override (defaults to Home Assistant). |
 | `time_format`          | `'12'`/`'24'`   | HA      | Hour format override. |
 | `px_per_min`           | number          | `1.6`   | Vertical scale: pixels per minute. |
 | `height_vh`            | number          | `80`    | Scroll area height in viewport units. |
-| `header_compact`       | boolean         | `false` | Smaller top header. |
 | `show_now_indicator`   | boolean         | `true`  | Red “now” line when viewing the current week. |
-| `show_all_day`         | boolean         | `true`  | Show all-day pill row. |
 | `remember_offset`      | boolean         | `true`  | Persist vertical scroll between reloads. |
 | `data_refresh_minutes` | number          | `5`     | Re-fetch calendars every N minutes (1–60). |
 | `weather_entity`       | string          | —       | Optional `weather.*` entity to show daily weather in headers. |
-| `weather_days`         | number          | `7`     | Days of weather to show (capped by your forecast). |
-| `weather_compact`      | boolean         | `false` | Compact weather display in headers. |
 
 ---
 
@@ -149,6 +137,7 @@ The most useful docs live in the `/docs` directory:
 - **[0001: Forecast data source](docs/adr/0001-forecast-data-source.md)** – Why we use the service/REST/attributes fallback order.
 - **[0002: Week start = today](docs/adr/0002-week-start-today.md)** – Rationale for starting the 7-day grid from the current day.
 - **[0003: Weather rendering in headers](docs/adr/0003-weather-rendering-in-headers.md)** – Design choices for minimal, consistent weather display.
+- **[0005: Remove legacy options](docs/adr/0005-remove-legacy-options.md)** – Cleanup and renaming of configuration.
 
 See **[CONTRIBUTING.md](CONTRIBUTING.md)** for guidelines on filing issues and sending PRs.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,8 +8,7 @@
   - Fetches events via Home Assistant REST API:
     `GET /api/calendars/<calendar.entity>?start=<ISO>&end=<ISO>`
   - Lays out all-day and timed events, computes lanes, draws “now” line.
-  - Supports options: `first_day`, `slot_*`, `px_per_min`, `remember_offset`, etc.
-  - (From v0.8.0) Week start can be **today**.
+  - Supports options: `view_*`, `px_per_min`, `remember_offset`, etc.
   - If `weather_entity` is set, the card fetches forecast data and renders a compact icon and hi/low in each day header (see ADR-0001).
 
 See `/docs/adr` for design decisions and trade-offs.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -30,14 +30,11 @@ npm run build
      - entity: calendar.example
        name: Example
        color: '#3f51b5'
-   first_day: today
-   slot_min_time: '07:00:00'
-   slot_max_time: '22:00:00'
+   view_start_time: '07:00:00'
+   view_end_time: '22:00:00'
    px_per_min: 0.8
    weather_entity: weather.integra_langsbau_1_3
-   weather_days: 7
-   weather_compact: false
-   ```
+  ```
 4. Hard-refresh the dashboard (disable cache) after each change.
 
 ## Lint & Typecheck

--- a/docs/adr/0002-week-start-today.md
+++ b/docs/adr/0002-week-start-today.md
@@ -1,6 +1,6 @@
 # ADR 0002 — Week Start = Today
 
-**Status**: Accepted  
+**Status**: Superseded by ADR 0005
 **Date**: 2025-08-28
 
 ## Context

--- a/docs/adr/0005-remove-legacy-options.md
+++ b/docs/adr/0005-remove-legacy-options.md
@@ -1,0 +1,17 @@
+# ADR 0005 — Remove Legacy Options and Rename Time Grid Settings
+
+**Status**: Accepted
+**Date**: 2025-08-31
+
+## Context
+Early versions exposed several configuration flags (`start_today`, `first_day`, `show_all_day`, `header_compact`, `weather_days`, `weather_compact`, `storage_key`) and generic `slot_*` names. They added complexity and were rarely used.
+
+## Decision
+- Drop legacy options: `start_today`, `first_day`, `show_all_day`, `header_compact`, `weather_days`, `weather_compact`, and `storage_key`.
+- Rename `slot_min_time`, `slot_max_time`, and `slot_minutes` to `view_start_time`, `view_end_time`, and `view_slot_minutes`.
+- Always show the all-day row and anchor the 7-day view to the current day.
+- Weather forecast always covers the card's 7-day window.
+
+## Consequences
+- Simplified configuration surface for future UI editor.
+- Existing dashboards using removed options must update their YAML.

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,60 +8,45 @@ export type MultiCalendarGridCardConfig = {
   type?: string;
   entities: EntityCfg[];
 
-  /** TIME GRID */
-  first_day?: number | "today";
-  start_today?: boolean;
-  slot_min_time?: string;
-  slot_max_time?: string;
-  slot_minutes?: number;
+  /** VIEW */
+  view_start_time?: string;
+  view_end_time?: string;
+  view_slot_minutes?: number;
   locale?: string;
   time_format?: "12" | "24";
   show_now_indicator?: boolean;
-  show_all_day?: boolean;
 
   /** LAYOUT */
-  header_compact?: boolean;
   height_vh?: number;
   px_per_min?: number;
   remember_offset?: boolean;
-  storage_key?: string;
 
   /** DATA */
   data_refresh_minutes?: number;
 
   /** WEATHER */
   weather_entity?: string;
-  weather_days?: number;
-  weather_compact?: boolean;
 };
 
 export const DEFAULTS: Required<
   Pick<
     MultiCalendarGridCardConfig,
-    | "slot_min_time"
-    | "slot_max_time"
-    | "slot_minutes"
+    | "view_start_time"
+    | "view_end_time"
+    | "view_slot_minutes"
     | "show_now_indicator"
-    | "show_all_day"
     | "height_vh"
     | "remember_offset"
-    | "header_compact"
     | "data_refresh_minutes"
     | "px_per_min"
-    | "storage_key"
-    | "start_today"
   >
 > = {
-  slot_min_time: "07:00:00",
-  slot_max_time: "22:00:00",
-  slot_minutes: 30,
+  view_start_time: "07:00:00",
+  view_end_time: "22:00:00",
+  view_slot_minutes: 30,
   show_now_indicator: true,
-  show_all_day: true,
   height_vh: 80,
   remember_offset: true,
-  header_compact: false,
   data_refresh_minutes: 5,
   px_per_min: 1.6,
-  storage_key: `multi-calendar-grid-card.weekOffset`,
-  start_today: true,
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,14 +14,6 @@ export const addMinutes = (d: Date, mins: number) => {
   return x;
 };
 
-export const startOfWeek = (d: Date, firstDay: number) => {
-  const x = new Date(d);
-  const s = (x.getDay() + 7 - (firstDay % 7)) % 7;
-  x.setHours(0, 0, 0, 0);
-  x.setDate(x.getDate() - s);
-  return x;
-};
-
 export const startOfDay = (d: Date) => {
   const x = new Date(d);
   x.setHours(0, 0, 0, 0);


### PR DESCRIPTION
## Summary
- drop unused and legacy options
- rename slot_* settings to view_* equivalents
- document cleanup in new ADR and changelog

## Testing
- `npm run lint`
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4075322ec832db79b5cc8acd72511