### PR TITLE
Add basic Lovelace editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Added
+- Basic Lovelace editor so the card can be configured through the Home Assistant card picker.
 ### Removed
 - Legacy options `start_today`, `first_day`, `show_all_day`, `header_compact`, `weather_days`, `weather_compact`, and `storage_key`.
 - Renamed `slot_min_time`/`slot_max_time`/`slot_minutes` to `view_start_time`/`view_end_time`/`view_slot_minutes`.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,13 @@ Grab `multi-calendar-grid-card.js` from the latest GitHub Release and place it a
 
 ---
 
-## Configuration (YAML)
+## Configuration
+
+### Configuration (UI)
+
+The card includes a basic editor and appears in Home Assistant's card picker. Use **Add Card → Multi-Calendar Grid Card** and configure options through the form. Advanced setups can still be done in YAML as documented below.
+
+### Configuration (YAML)
 
 Add the card to a view:
 

--- a/src/multi-calendar-grid-card-editor.ts
+++ b/src/multi-calendar-grid-card-editor.ts
@@ -1,0 +1,81 @@
+import { LitElement, html, css, nothing } from "lit";
+import { DEFAULTS, MultiCalendarGridCardConfig } from "./config";
+
+/** Simple ha-form based editor for Multi-Calendar Grid Card */
+export class MultiCalendarGridCardEditor extends LitElement {
+  hass?: any;
+  private _config: MultiCalendarGridCardConfig = { entities: [] };
+
+  private _schema: any = [
+    {
+      name: "entities",
+      type: "array",
+      schema: [
+        { name: "entity", selector: { entity: { domain: "calendar" } } },
+        { name: "name", selector: { text: {} } },
+        { name: "color", selector: { color: {} } },
+      ],
+    },
+    { name: "view_start_time", selector: { time: {} } },
+    { name: "view_end_time", selector: { time: {} } },
+    { name: "view_slot_minutes", selector: { number: { min: 1, max: 180 } } },
+    { name: "locale", selector: { text: {} } },
+    {
+      name: "time_format",
+      selector: { select: { options: ["12", "24"], mode: "dropdown" } },
+    },
+    { name: "show_now_indicator", selector: { boolean: {} } },
+    { name: "height_vh", selector: { number: { min: 10, max: 200 } } },
+    { name: "px_per_min", selector: { number: { min: 0.1, max: 10, step: 0.1 } } },
+    { name: "remember_offset", selector: { boolean: {} } },
+    { name: "data_refresh_minutes", selector: { number: { min: 1, max: 60 } } },
+    { name: "weather_entity", selector: { entity: { domain: "weather" } } },
+  ];
+
+  static styles = css`
+    ha-form {
+      display: block;
+    }
+  `;
+
+  setConfig(config: MultiCalendarGridCardConfig): void {
+    this._config = { ...config };
+  }
+
+  render() {
+    if (!this.hass) return nothing;
+    const data = { ...DEFAULTS, ...this._config } as any;
+    return html`
+      <ha-form
+        .hass=${this.hass}
+        .data=${data}
+        .schema=${this._schema}
+        @value-changed=${this._valueChanged}
+      ></ha-form>
+    `;
+  }
+
+  private _valueChanged(ev: CustomEvent) {
+    ev.stopPropagation();
+    const value = ev.detail.value as MultiCalendarGridCardConfig;
+    const config: any = { ...value };
+    // Remove defaults to keep YAML tidy
+    Object.entries(DEFAULTS).forEach(([k, v]) => {
+      if (config[k] === v) delete config[k];
+    });
+    this._config = config;
+    this.dispatchEvent(
+      new CustomEvent("config-changed", {
+        detail: { config },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+}
+
+customElements.define(
+  "multi-calendar-grid-card-editor",
+  MultiCalendarGridCardEditor
+);
+

--- a/src/multi-calendar-grid-card.ts
+++ b/src/multi-calendar-grid-card.ts
@@ -160,10 +160,9 @@ export class MultiCalendarGridCard extends LitElement {
     };
   }
 
-  static getConfigElement() {
-    const el = document.createElement("div");
-    el.innerHTML = `<div style="padding:8px">Use YAML to configure this card. Editor coming later. (v${VERSION})</div>`;
-    return el;
+  static async getConfigElement() {
+    await import("./multi-calendar-grid-card-editor");
+    return document.createElement("multi-calendar-grid-card-editor");
   }
 
   /** Config */


### PR DESCRIPTION
## Summary
- add ha-form based configuration editor for Multi-Calendar Grid Card
- expose editor through `getConfigElement` for card picker
- document UI configuration option

## Testing
- `npm run lint`
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b410752dd4832d9c41b72f949a249a