### PR TITLE
fix: update artifact paths for renamed card

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,5 +19,5 @@ jobs:
       - run: npm run build
       - uses: actions/upload-artifact@v4
         with:
-          name: multi-calendar-grid-card
-          path: dist/multi-calendar-grid-card.js
+          name: grid-calendar-card
+          path: dist/grid-calendar-card.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,4 +22,4 @@ jobs:
       - run: npm run build
       - uses: softprops/action-gh-release@v1
         with:
-          files: dist/multi-calendar-grid-card.js
+          files: dist/grid-calendar-card.js


### PR DESCRIPTION
## Summary
- update CI artifact paths to dist/grid-calendar-card.js
- adjust release workflow to match renamed build output

## Testing
- `npm run lint`
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b42247e168832d8924d7865df14411