### PR TITLE
fix: prefix custom card type in stub config

### DIFF
--- a/src/grid-calendar-card.ts
+++ b/src/grid-calendar-card.ts
@@ -154,7 +154,7 @@ export class GridCalendarCard extends LitElement {
           }))
         : [{ entity: "calendar.calendar", name: "Calendar", color: palette[0] }];
     return {
-      type: CARD_TAG,
+      type: `custom:${CARD_TAG}`,
       entities,
       ...DEFAULTS,
     };


### PR DESCRIPTION
## Summary
- prefix `getStubConfig` type with `custom:` so adding card via UI uses correct type

## Testing
- `npm run lint`
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b429562bb8832db602f77fb3f8ee3e