### PR TITLE
feat: refine grid visibility and layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Basic Lovelace editor so the card can be configured through the Home Assistant card picker.
 ### Changed
-- Grid lines now render behind events with clearer contrast.
-- Header, legend spacing, and toolbar buttons adjusted for a cleaner layout.
+- Grid lines now have stronger contrast while remaining behind events.
+- Toolbar moved above the legend and spacing refined for a cleaner layout.
 - Locale selector is now a dropdown in the editor (`en`/`de`).
 - Default time format is 24-hour and the UI respects it for time inputs.
 - Renamed project and custom element tag to Grid Calendar Card (`grid-calendar-card`).

--- a/src/grid-calendar-card.ts
+++ b/src/grid-calendar-card.ts
@@ -98,11 +98,12 @@ export class GridCalendarCard extends LitElement {
   static styles = css`
     :host{display:block}
     ha-card{border-radius:16px; overflow:hidden}
-    .hdr{display:flex; justify-content:space-between; align-items:center; gap:16px; margin:16px 16px 0}
-    .legend{display:flex; gap:12px; flex-wrap:wrap; font-size:14px; margin:0 16px 12px}
-    .legend .item{display:flex; align-items:center; cursor:pointer; user-select:none; padding:8px 12px; border-radius:999px}
+    .hdr{display:flex; flex-direction:column; align-items:flex-start; gap:12px; margin:16px 16px 0}
+    .toolbar{display:flex; gap:8px; flex-wrap:wrap}
     .toolbar button{all:unset; cursor:pointer; padding:8px 16px; border-radius:999px; background:rgba(0,0,0,.06)}
     .toolbar button:focus{outline:2px solid var(--primary-color)}
+    .legend{display:flex; gap:12px; flex-wrap:wrap; font-size:14px; margin:0 0 12px}
+    .legend .item{display:flex; align-items:center; cursor:pointer; user-select:none; padding:8px 12px; border-radius:999px}
     .error{color:#fff; background:#d32f2f; padding:6px 10px; border-radius:8px; font-size:12px; margin:0 12px 8px}
     .empty{color:var(--secondary-text-color); padding:8px 12px; font-size:12px}
     .scroll{height: var(--mcg-height, 80vh); margin: 0 12px 12px; overflow-y:auto; overscroll-behavior:contain; border:1px solid var(--divider-color,#e0e0e0); border-radius:12px; background:var(--divider-color,#e0e0e0)}
@@ -114,11 +115,11 @@ export class GridCalendarCard extends LitElement {
     .allday{padding:6px 8px; display:flex; flex-wrap:wrap; gap:6px 6px; border-bottom:1px solid var(--divider-color,#e0e0e0); overflow:hidden}
     .pill{background: var(--secondary-background-color, rgba(0,0,0,.08)); color: var(--primary-text-color,#111); border-radius:10px; padding:2px 8px; font-size:12px; max-width:100%; white-space:nowrap; overflow:hidden; text-overflow:ellipsis}
     .timecol{background:var(--card-background-color,#fff); position:relative}
-    .tick{position:absolute; left:0; right:0; border-top:1px solid rgba(0,0,0,.15)}
-    .tick.minor{border-top:1px dashed rgba(0,0,0,.1)}
+    .tick{position:absolute; left:0; right:0; border-top:1px solid rgba(0,0,0,.25)}
+    .tick.minor{border-top:1px dashed rgba(0,0,0,.15)}
     .hour-label{position:absolute; top:-8px; left:6px; font-size:12px; color:var(--secondary-text-color)}
     .body{position:relative}
-    .event{position:absolute; border-radius:10px; padding:6px 8px; box-sizing:border-box; font-size:12px; line-height:1.15; overflow:hidden; cursor:pointer; box-shadow:0 1px 3px rgba(0,0,0,.12)}
+    .event{position:absolute; z-index:1; border-radius:10px; padding:6px 8px; box-sizing:border-box; font-size:12px; line-height:1.15; overflow:hidden; cursor:pointer; box-shadow:0 1px 3px rgba(0,0,0,.12)}
     .event .title{font-weight:700}
     .now{position:absolute; left:0; right:0; height:2px; background: var(--error-color,#e53935); z-index:3}
     .footer{font-size:10px; color:var(--secondary-text-color); text-align:right; margin:4px 12px 10px}
@@ -449,9 +450,6 @@ export class GridCalendarCard extends LitElement {
     return html`
       <ha-card>
         <div class="hdr">
-          <div class="legend">
-            ${this._config.entities.map((e) => this._legendItem(e))}
-          </div>
           <div class="toolbar">
             <button type="button" aria-label="${tr(lang, "aria_prev_week")}" @click=${() => this._shiftWeek(-1)}>${tr(
               lang,
@@ -465,6 +463,9 @@ export class GridCalendarCard extends LitElement {
               lang,
               "next"
             )}</button>
+          </div>
+          <div class="legend">
+            ${this._config.entities.map((e) => this._legendItem(e))}
           </div>
         </div>
 
@@ -544,7 +545,7 @@ export class GridCalendarCard extends LitElement {
       (Number(this._config.view_slot_minutes) || DEFAULTS.view_slot_minutes) *
       pxPerMin;
     const hourPx = 60 * pxPerMin;
-    const bg = `background-image: repeating-linear-gradient(to bottom, rgba(0,0,0,.1) 0, rgba(0,0,0,.1) 1px, transparent 1px, transparent ${slotPx}px), repeating-linear-gradient(to bottom, rgba(0,0,0,.15) 0, rgba(0,0,0,.15) 1px, transparent 1px, transparent ${hourPx}px);`;
+    const bg = `background-image: repeating-linear-gradient(to bottom, rgba(0,0,0,.15) 0, rgba(0,0,0,.15) 1px, transparent 1px, transparent ${slotPx}px), repeating-linear-gradient(to bottom, rgba(0,0,0,.25) 0, rgba(0,0,0,.25) 1px, transparent 1px, transparent ${hourPx}px);`;
     const today = startOfDay(new Date());
 
     for (let d = 0; d < 7; d++) {


### PR DESCRIPTION
## Summary
- increase contrast of calendar grid lines while keeping them behind events
- stack toolbar above legend with cleaner spacing
- document 24-hour default and locale dropdown

## Testing
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b439ab5d54832daa085cb3a2898120