### PR TITLE
Relax config requirements and default to 24h clock

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,7 @@ export type EntityCfg = {
 
 export type GridCalendarCardConfig = {
   type?: string;
-  entities: EntityCfg[];
+  entities?: EntityCfg[];
 
   /** VIEW */
   view_start_time?: string;

--- a/src/grid-calendar-card-editor.ts
+++ b/src/grid-calendar-card-editor.ts
@@ -50,7 +50,7 @@ export class GridCalendarCardEditor extends LitElement {
   `;
 
   setConfig(config: GridCalendarCardConfig): void {
-    this._config = { ...config };
+    this._config = { entities: [], ...config };
   }
 
   render() {

--- a/src/grid-calendar-card.ts
+++ b/src/grid-calendar-card.ts
@@ -57,7 +57,7 @@ export class GridCalendarCard extends LitElement {
   hass: any;
 
   /** Internal (reactive via static properties) */
-  private _config!: GridCalendarCardConfig;
+  private _config!: GridCalendarCardConfig & { entities: EntityCfg[] };
   private _error: string | null = null;
   private _weekOffset = 0;
   private _weekAnchor!: Date; // start of visible 7-day window
@@ -167,11 +167,13 @@ export class GridCalendarCard extends LitElement {
 
   /** Config */
   setConfig(cfg: GridCalendarCardConfig) {
-    if (!cfg || !Array.isArray(cfg.entities) || cfg.entities.length === 0) {
-      throw new Error("Config must include at least one entity in 'entities'.");
+    if (!cfg) throw new Error("Invalid config");
+    if (cfg.view_start_time && !isHHMMSS(cfg.view_start_time)) {
+      throw new Error("view_start_time must be HH:MM:SS");
     }
-    if (!isHHMMSS(cfg.view_start_time)) throw new Error("view_start_time must be HH:MM:SS");
-    if (!isHHMMSS(cfg.view_end_time)) throw new Error("view_end_time must be HH:MM:SS");
+    if (cfg.view_end_time && !isHHMMSS(cfg.view_end_time)) {
+      throw new Error("view_end_time must be HH:MM:SS");
+    }
     const sm = Number(cfg.view_slot_minutes ?? DEFAULTS.view_slot_minutes);
     if (!Number.isFinite(sm) || sm <= 0 || sm > 180) {
       throw new Error("view_slot_minutes must be a number between 1 and 180.");
@@ -180,6 +182,7 @@ export class GridCalendarCard extends LitElement {
     // Merge defaults
     this._config = {
       ...DEFAULTS,
+      entities: [],
       ...cfg,
     };
 

--- a/src/locale.ts
+++ b/src/locale.ts
@@ -4,9 +4,9 @@ export const detectLang = (hass: any, cfgLocale?: string): string =>
   cfgLocale || hass?.locale?.language || "en";
 
 export const detectHourCycle = (
-  hass: any,
+  _hass: any,
   cfgTimeFormat?: string,
-): HourCycle => ((cfgTimeFormat || hass?.locale?.time_format) === "12" ? "h12" : "h23");
+): HourCycle => (cfgTimeFormat === "12" ? "h12" : "h23");
 
 export const shortDate = (d: Date, lang: string) =>
   new Intl.DateTimeFormat(lang, { day: "2-digit", month: "short" }).format(d);


### PR DESCRIPTION
## Summary
- Allow Grid Calendar card to load with no entities configured
- Default hour cycle to 24h unless `time_format` explicitly set to `"12"`

## Testing
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68b4952781d0832dad04175b21c85eff