### PR TITLE
Preserve card settings and honor 24‑hour time

### DIFF
--- a/src/grid-calendar-card-editor.ts
+++ b/src/grid-calendar-card-editor.ts
@@ -56,9 +56,13 @@ export class GridCalendarCardEditor extends LitElement {
   render() {
     if (!this.hass) return nothing;
     const data = { ...DEFAULTS, ...this._config } as any;
+    const hass = {
+      ...this.hass,
+      locale: { ...this.hass.locale, time_format: data.time_format },
+    };
     return html`
       <ha-form
-        .hass=${this.hass}
+        .hass=${hass}
         .data=${data}
         .schema=${this._schema}
         @value-changed=${this._valueChanged}
@@ -70,10 +74,6 @@ export class GridCalendarCardEditor extends LitElement {
     ev.stopPropagation();
     const value = ev.detail.value as GridCalendarCardConfig;
     const config: any = { ...this._config, ...value };
-    // Remove defaults to keep YAML tidy
-    Object.entries(DEFAULTS).forEach(([k, v]) => {
-      if (config[k] === v) delete config[k];
-    });
     this._config = config;
     this.dispatchEvent(
       new CustomEvent("config-changed", {


### PR DESCRIPTION
## Summary
- Ensure card editor always saves configuration values instead of stripping defaults
- Pass selected time format to the editor so time pickers respect 24‑hour preference

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b498d79e64832d8f5a85818962f0c1