### PR TITLE
fix: load ha-form in editor

### DIFF
--- a/src/grid-calendar-card-editor.ts
+++ b/src/grid-calendar-card-editor.ts
@@ -1,26 +1,51 @@
 import { LitElement, html, css, nothing } from "lit";
 import { DEFAULTS, GridCalendarCardConfig } from "./config";
 
+declare global {
+  interface Window {
+    loadHaForm?: () => Promise<void>;
+  }
+}
+
 /** Simple ha-form based editor for Grid Calendar Card */
 export class GridCalendarCardEditor extends LitElement {
   hass?: any;
   private _config: GridCalendarCardConfig = { entities: [] };
 
+  constructor() {
+    super();
+    window.loadHaForm?.();
+  }
+
   private _schema: any = [
     {
       name: "entities",
+      label: "Calendars",
       type: "array",
       schema: [
-        { name: "entity", selector: { entity: { domain: "calendar" } } },
-        { name: "name", selector: { text: {} } },
-        { name: "color", selector: { color: {} } },
+        {
+          name: "entity",
+          label: "Entity",
+          selector: { entity: { domain: "calendar" } },
+        },
+        { name: "name", label: "Name", selector: { text: {} } },
+        { name: "color", label: "Color", selector: { color: {} } },
       ],
     },
-    { name: "view_start_time", selector: { time: {} } },
-    { name: "view_end_time", selector: { time: {} } },
-    { name: "view_slot_minutes", selector: { number: { min: 1, max: 180 } } },
+    {
+      name: "view_start_time",
+      label: "View start time",
+      selector: { time: {} },
+    },
+    { name: "view_end_time", label: "View end time", selector: { time: {} } },
+    {
+      name: "view_slot_minutes",
+      label: "View slot minutes",
+      selector: { number: { min: 1, max: 180 } },
+    },
     {
       name: "locale",
+      label: "Locale",
       selector: {
         select: {
           options: [
@@ -33,14 +58,39 @@ export class GridCalendarCardEditor extends LitElement {
     },
     {
       name: "time_format",
+      label: "Time format",
       selector: { select: { options: ["12", "24"], mode: "dropdown" } },
     },
-    { name: "show_now_indicator", selector: { boolean: {} } },
-    { name: "height_vh", selector: { number: { min: 10, max: 200 } } },
-    { name: "px_per_min", selector: { number: { min: 0.1, max: 10, step: 0.1 } } },
-    { name: "remember_offset", selector: { boolean: {} } },
-    { name: "data_refresh_minutes", selector: { number: { min: 1, max: 60 } } },
-    { name: "weather_entity", selector: { entity: { domain: "weather" } } },
+    {
+      name: "show_now_indicator",
+      label: "Show now indicator",
+      selector: { boolean: {} },
+    },
+    {
+      name: "height_vh",
+      label: "Height (vh)",
+      selector: { number: { min: 10, max: 200 } },
+    },
+    {
+      name: "px_per_min",
+      label: "Pixels per minute",
+      selector: { number: { min: 0.1, max: 10, step: 0.1 } },
+    },
+    {
+      name: "remember_offset",
+      label: "Remember offset",
+      selector: { boolean: {} },
+    },
+    {
+      name: "data_refresh_minutes",
+      label: "Data refresh minutes",
+      selector: { number: { min: 1, max: 60 } },
+    },
+    {
+      name: "weather_entity",
+      label: "Weather entity",
+      selector: { entity: { domain: "weather" } },
+    },
   ];
 
   static styles = css`
@@ -80,13 +130,9 @@ export class GridCalendarCardEditor extends LitElement {
         detail: { config },
         bubbles: true,
         composed: true,
-      })
+      }),
     );
   }
 }
 
-customElements.define(
-  "grid-calendar-card-editor",
-  GridCalendarCardEditor
-);
-
+customElements.define("grid-calendar-card-editor", GridCalendarCardEditor);


### PR DESCRIPTION
## Summary
- ensure grid calendar card editor loads Home Assistant form helpers
- add labels for config fields so UI shows friendly names

## Testing
- `npm run lint`
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b49c19f728832d9d15508565ecbe04