### PR TITLE
feat: support legacy card tag and YAML install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ Grab `multi-calendar-grid-card.js` from the latest GitHub Release and place it a
 
 > Tip: After updates, hard-refresh the browser (Ctrl/Cmd-Shift-R) to bust cache.
 
+If you manage your dashboard in `ui-lovelace.yaml`, add the resource at the top level:
+
+```yaml
+resources:
+  - url: /local/multi-calendar-grid-card/multi-calendar-grid-card.js
+    type: module
+```
+
 ---
 
 ## Configuration (YAML)
@@ -80,6 +88,8 @@ weather_entity: weather.integra_langsbau_1_3
 weather_days: 7            # default 7
 weather_compact: false     # false = show icon + hi/low; true = tighter
 ```
+
+> Legacy alias: `type: custom:grid-calendar-card` still works.
 
 ---
 

--- a/src/multi-calendar-grid-card.ts
+++ b/src/multi-calendar-grid-card.ts
@@ -37,6 +37,7 @@ import {
 
 /** Public card type & version */
 export const CARD_TAG = "multi-calendar-grid-card";
+export const LEGACY_TAG = "grid-calendar-card";
 export const VERSION = "0.8.1";
 
 
@@ -697,6 +698,7 @@ function hash(s: string): string {
 
 /** Define element (no decorator) and card registration */
 if (!customElements.get(CARD_TAG)) customElements.define(CARD_TAG, MultiCalendarGridCard as any);
+if (!customElements.get(LEGACY_TAG)) customElements.define(LEGACY_TAG, MultiCalendarGridCard as any);
 (window as any).customCards = (window as any).customCards || [];
 if (!(window as any).customCards.find((c: any) => c.type === CARD_TAG)) {
   (window as any).customCards.push({


### PR DESCRIPTION
## Summary
- register `grid-calendar-card` as an alias for `multi-calendar-grid-card`
- document how to add the resource in `ui-lovelace.yaml`
- note that the old card tag still works

## Testing
- `npm run lint`
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4d4ff7aa8832d8259ef56ce2012f6